### PR TITLE
Fix: Correct SyntaxError in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,5 +85,5 @@ else:
         # Historical Data Table
         st.subheader("Historical Data")
         st.dataframe(df.sort_index(ascending=False).head())
-        else:
-            st.error("Error fetching data. Please check the stock symbol.")
+    else:
+        st.error("Error fetching data. Please check the stock symbol.")


### PR DESCRIPTION
This commit fixes a SyntaxError caused by an incorrectly indented `else` statement. The `else` block was not aligned with its corresponding `if` statement, leading to a fatal error.

The indentation has been corrected to ensure the script executes correctly.